### PR TITLE
snowflake 0.8.0 :snowflake:

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 upload_channels:
   - sfe1ed40
-
-channels:
-  - https://staging.continuum.io/prefect/fs/snowflake_legacy-feedstock/pr1/714abaa

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_channels:
+  - sfe1ed40
+
+channels:
+  - https://staging.continuum.io/prefect/fs/snowflake_legacy-feedstock/pr1/6ecd0cd
+  - https://staging.continuum.io/prefect/fs/snowflake.core-feedstock/pr1/3dd87e0

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,4 +3,3 @@ upload_channels:
 
 channels:
   - https://staging.continuum.io/prefect/fs/snowflake_legacy-feedstock/pr1/6ecd0cd
-  - https://staging.continuum.io/prefect/fs/snowflake.core-feedstock/pr1/3dd87e0

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,4 +2,4 @@ upload_channels:
   - sfe1ed40
 
 channels:
-  - https://staging.continuum.io/prefect/fs/snowflake_legacy-feedstock/pr1/6ecd0cd
+  - https://staging.continuum.io/prefect/fs/snowflake_legacy-feedstock/pr1/714abaa

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -93,3 +93,8 @@ about:
 extra:
   recipe-maintainers:
     - lorepirri
+  skip-lints:
+    - missing_wheel
+    - missing_pip_check
+    - wrong_output_script_key
+    - missing_python_build_tool

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,95 @@
+{% set name = "snowflake" %}
+{% set version = "0.8.0" %}
+
+package:
+  name: {{ name|lower }}-packages
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: d3fa09f1e939de69251d7400b2343893b249953ec90564031097e726c50e2c3c
+  patches:
+    - patches/0001-fix-pyproject.patch
+
+build:
+  number: 0
+  # snowflake.core not available for s390x
+  skip: true  # [py<38 or py>311 or s390x]
+
+requirements:
+  build:
+    - patch     # [not win]
+    - m2-patch  # [win]
+  host:
+    # this is needed here in the multi-output recipe
+    # to make the PYTHON variable being set for later
+    # in the script section
+    - python
+
+outputs:
+  - name: {{ name }}
+    build:
+      # snowflake.core not available for s390x
+      skip: true  # [py<38 or py>311 or s390x]
+      script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed -vv
+    requirements:
+      host:
+        - python
+        - hatchling
+        - pip
+      run:
+        - python
+        - snowflake.core =={{ version }}
+        - snowflake_legacy
+    test:
+      imports:
+        - snowflake
+        - snowflake._legacy
+        - snowflake.core
+      requires:
+        - pip
+      commands:
+        - pip check
+
+  - name: {{ name }}-ml
+    build:
+      # snowflake.core not available for s390x
+      skip: true  # [py<38 or py>311 or s390x]
+    requirements:
+      host:
+        - python
+      run:
+        - python
+        - {{ pin_subpackage('snowflake', exact=True) }}
+        - snowflake-ml-python ==1.4.0
+    test:
+      imports:
+        - snowflake.ml
+        - snowflake.ml.fileset
+        - snowflake.ml.model
+        - snowflake.ml.modeling
+        - snowflake.ml.registry
+        - snowflake.ml.utils
+      requires:
+        - pip
+      commands:
+        # On win-64 this does not pick up xgboost for some reason, so skip it.
+        - pip check   # [not win]
+
+about:
+  home: https://pypi.org/project/snowflake
+  license: Apache-2.0
+  license_family: Apache
+  license_file: LICENSE
+  summary: Snowflake Python API
+  description: |
+    The Snowflake Python API is the unified Python API across
+    all Snowflake workloads, providing APIs for all Snowflake
+    resources across data engineering, Snowpark, Snowpark ML,
+    and client application workloads.
+  doc_url: https://docs.snowflake.com/developer-guide/snowflake-python-api/snowflake-python-overview
+  dev_url: https://pypi.org/project/snowflake
+
+extra:
+  recipe-maintainers:
+    - lorepirri

--- a/recipe/patches/0001-fix-pyproject.patch
+++ b/recipe/patches/0001-fix-pyproject.patch
@@ -1,0 +1,26 @@
+From 8b00522c3ae69e6a37bfe81fa3d1969e45f96ae1 Mon Sep 17 00:00:00 2001
+From: Lorenzo Pirritano <lpirritano@anaconda.com>
+Date: Thu, 2 May 2024 18:59:00 +0200
+Subject: [PATCH] fix pyproject
+
+---
+ pyproject.toml | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/pyproject.toml b/pyproject.toml
+index 22d4f03..a567234 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -59,9 +59,6 @@ ml = [
+ [tool.hatch.metadata]
+ allow-direct-references = true
+ 
+-[tool.hatch.metadata.hooks.custom]
+-path = '../../scripts/hatch_hooks.py'
+-
+ [tool.hatch.build]
+ directory = '../../dist'
+ dev-mode-dirs = ['src']
+-- 
+2.39.1
+


### PR DESCRIPTION
snowflake 0.8.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4534]
- Upstream repository: private
- pypi: https://pypi.org/project/snowflake/0.8.0
- pypi inspector: https://inspector.pypi.io/project/snowflake/0.8.0
- Relevant dependency PRs:
  - AnacondaRecipes/snowflake.core-feedstock#1
  - AnacondaRecipes/snowflake_legacy-feedstock#1

### Explanation of changes:

- new feedstock, only on `pypi`, namespace for `snowflake`
- multi-output, optional `snowflake-ml` mapping `snowflake[ml]`


[PKG-4534]: https://anaconda.atlassian.net/browse/PKG-4534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ